### PR TITLE
Add Falco exception for clawdbot shell usage

### DIFF
--- a/cluster/infrastructure/falco/falco/release.yaml
+++ b/cluster/infrastructure/falco/falco/release.yaml
@@ -146,6 +146,11 @@ spec:
               - /bin/bash
               - bash
               - bash ./data/check
+          - name: clawdbot-shell
+            fields:
+            - container.image.repository
+            values:
+            - - ghcr.io/openclaw/openclaw
           override:
             exceptions: append
       cilium-socket-exceptions.yaml: |-


### PR DESCRIPTION
## Problem

Falco is alerting on `Run shell untrusted` for clawdbot container, which legitimately uses shell commands for:
- kubectl operations
- Other cluster monitoring tasks

## Fix

Add exception for `ghcr.io/openclaw/openclaw` container image to the existing "Run shell untrusted" rule exceptions.

```yaml
- name: clawdbot-shell
  fields:
  - container.image.repository
  values:
  - - ghcr.io/openclaw/openclaw
```

## Notes

This follows the existing pattern for other containers (cloudnative-pg, frigate) that legitimately need shell access.