### PR TITLE
Bump hortusfox haproxy resource limits

### DIFF
--- a/cluster/apps/hortusfox/database/cluster.yaml
+++ b/cluster/apps/hortusfox/database/cluster.yaml
@@ -40,8 +40,8 @@ spec:
       timeoutSeconds: 20
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
-      limits:
-        cpu: 500m
+        cpu: 200m
         memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 512Mi


### PR DESCRIPTION
## Problem

HAProxy pods in hortusfox Percona cluster showing CPU throttling (~48%):

```
[info] CPUThrottlingHigh
namespace: hortusfox
pod: hortusfox-mysql-haproxy-0
container: haproxy
46.44% throttling of CPU
```

## Fix

Increase resource limits for haproxy in PerconaXtraDBCluster:

| | Before | After |
|--|--------|-------|
| requests.cpu | 100m | 200m |
| requests.memory | 128Mi | 256Mi |
| limits.cpu | 500m | 1000m |
| limits.memory | 256Mi | 512Mi |